### PR TITLE
Fix alarm seed

### DIFF
--- a/src/core0_audio.rs
+++ b/src/core0_audio.rs
@@ -528,7 +528,6 @@ pub fn audio_task(
     }
     let mut should_sleep = true;
     let mut alarm_time: Option<NaiveDateTime>;
-
     if reschedule {
         watchdog.feed();
         info!("Scheduling new recording");
@@ -726,19 +725,19 @@ pub fn schedule_audio_rec(
     let current_time = synced_date_time.get_adjusted_dt(timer);
 
     if device_config.config().audio_seed > 0 {
-        // need 4  bytes for the month so shift day by 4
-        seed = current_time.month() as u64
-            + ((current_time.day() as u64) << 4)
-            + device_config.config().audio_seed as u64;
         wakeup = NaiveDateTime::new(
             current_time.date(),
             NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+        );
+
+        seed = u64::wrapping_add(
+            wakeup.and_utc().timestamp_millis() as u64,
+            device_config.config().audio_seed as u64,
         );
     } else {
         seed = synced_date_time.date_time_utc.and_utc().timestamp() as u64;
         wakeup = current_time;
     };
-
     let mut rng = RNG::<WyRand, u16>::new(seed);
     let r_max: u16 = 65535u16;
     let short_chance: u16 = r_max / 4;

--- a/src/core0_audio.rs
+++ b/src/core0_audio.rs
@@ -380,7 +380,6 @@ pub fn audio_task(
 
         if recording_type.is_none() && scheduled {
             // check we haven't missed the alarm somehow
-
             if let Some(alarm) = alarm_date_time {
                 let synced = synced_date_time.get_adjusted_dt(timer);
                 let until_alarm = (alarm - synced_date_time.get_adjusted_dt(timer)).num_minutes();
@@ -728,7 +727,6 @@ pub fn schedule_audio_rec(
 
     if device_config.config().audio_seed > 0 {
         // need 4  bytes for the month so shift day by 4
-
         seed = current_time.month() as u64
             + ((current_time.day() as u64) << 4)
             + device_config.config().audio_seed as u64;
@@ -749,6 +747,7 @@ pub fn schedule_audio_rec(
     let long_pause: u64 = 40 * 60;
     let long_window: u64 = 20 * 60;
 
+    // if a seed is set always start alarm from 0am to keep consistent accross devices.So  will need to generate numbers until alarm is valid
     while wakeup <= current_time {
         let r = rng.generate();
         let mut wake_in;


### PR DESCRIPTION
Fix bug where alarm wasn't checked to be expired  always
Fix bug where using an audio seed would cause the alarm to always be a constant minute away and not actually be synchronized