### PR TITLE
Fix shutdown status

### DIFF
--- a/src/core0_audio.rs
+++ b/src/core0_audio.rs
@@ -170,9 +170,6 @@ pub fn audio_task(
     }
 
     let mut duration = 60;
-    if DEV_MODE {
-        duration = 10;
-    }
     let mut recording_type = None;
     let mut user_recording_requested = false;
     let mut thermal_requested_audio = false;
@@ -195,9 +192,6 @@ pub fn audio_task(
                     RecordingType::ThermalRequestedScheduledRecording => {
                         duration = 60;
                         thermal_requested_audio = true;
-                        if DEV_MODE {
-                            duration = 10;
-                        }
                     }
                     _ => {}
                 }

--- a/src/core0_audio.rs
+++ b/src/core0_audio.rs
@@ -257,8 +257,8 @@ pub fn audio_task(
         // let mut alarm_minutes = shared_i2c.get_alarm_minutes();
         let mut scheduled: bool = false;
 
-        // GP 30th Jan if alarm is set we always need to check against current time if the alarm wasnt triggered
-        // otherwise can have edge cases where tc2 agent code thinks we should rec but the alarm is later
+        // GP 30th Jan TODO if alarm is set we always need to check alarm against current time if the alarm wasnt triggered
+        // otherwise can have edge cases where tc2 agent status code thinks we should rec but the alarm is later
         let (_, flash_alarm) = get_audio_alarm(&mut flash_storage);
         if let Some(alarm) = flash_alarm {
             scheduled = true;

--- a/src/core0_audio.rs
+++ b/src/core0_audio.rs
@@ -170,6 +170,9 @@ pub fn audio_task(
     }
 
     let mut duration = 60;
+    if DEV_MODE {
+        duration = 10;
+    }
     let mut recording_type = None;
     let mut user_recording_requested = false;
     let mut thermal_requested_audio = false;
@@ -192,6 +195,9 @@ pub fn audio_task(
                     RecordingType::ThermalRequestedScheduledRecording => {
                         duration = 60;
                         thermal_requested_audio = true;
+                        if DEV_MODE {
+                            duration = 10;
+                        }
                     }
                     _ => {}
                 }
@@ -257,6 +263,8 @@ pub fn audio_task(
         // let mut alarm_minutes = shared_i2c.get_alarm_minutes();
         let mut scheduled: bool = false;
 
+        // GP 30th Jan if alarm is set we always need to check against current time if the alarm wasnt triggered
+        // otherwise can have edge cases where tc2 agent code thinks we should rec but the alarm is later
         let (_, flash_alarm) = get_audio_alarm(&mut flash_storage);
         if let Some(alarm) = flash_alarm {
             scheduled = true;
@@ -785,7 +793,7 @@ pub fn schedule_audio_rec(
                 start.hour(),
                 start.minute(),
             );
-            if wakeup > start {
+            if wakeup >= start {
                 if start < current_time {
                     if let AudioMode::AudioAndThermal = device_config.config().audio_mode {
                         //audio recording inside recording window

--- a/src/core1_sub_tasks.rs
+++ b/src/core1_sub_tasks.rs
@@ -353,7 +353,7 @@ pub fn get_existing_device_config_or_config_from_pi_on_initial_handshake(
                 if new_config.is_some() {
                     length_used = new_config.as_mut().unwrap().cursor_position;
                 }
-                let mut new_config_bytes = [0u8; 2400 + 105];
+                let mut new_config_bytes = [0u8; 2400 + 112];
                 new_config_bytes[0..length_used]
                     .copy_from_slice(&device_config[4..4 + length_used]);
                 if let Some(new_config) = &mut new_config {
@@ -401,7 +401,6 @@ pub fn get_existing_device_config_or_config_from_pi_on_initial_handshake(
                                 *existing_config.as_ref().unwrap() != *new_config
                             );
                         }
-
                         new_config_bytes[length_used..length_used + 2400]
                             .copy_from_slice(&new_config.motion_detection_mask.inner);
                         let slice_to_write = &new_config_bytes[0..length_used + 2400];

--- a/src/core1_task.rs
+++ b/src/core1_task.rs
@@ -1490,7 +1490,8 @@ pub fn core_1_task(
 
                 // if within 2 minutes of end of a window make status before doing audio rec
                 // this ensures we always make the status recording
-                if made_shutdown_status_recording
+                if !device_config.use_low_power_mode()
+                    || made_shutdown_status_recording
                     || &(synced_date_time.date_time_utc + Duration::minutes(2)) < window_end
                 {
                     //hanldes case where thermal recorder is doing recording

--- a/src/core1_task.rs
+++ b/src/core1_task.rs
@@ -885,10 +885,10 @@ pub fn core_1_task(
                 let should_end_current_recording = cptv_stream.is_some()
                     && ((this_frame_motion_detection.triggering_ended()
                         || frames_written >= max_length_in_frames
-                        || flash_storage.is_nearly_full())
+                        || (!making_status_recording && flash_storage.is_nearly_full()))
                         || (making_status_recording
                             && (frames_written >= status_recording_length_in_frames
-                                || flash_storage.is_nearly_full())));
+                                || flash_storage.is_full())));
 
                 motion_detection = Some(this_frame_motion_detection);
 

--- a/src/device_config.rs
+++ b/src/device_config.rs
@@ -292,7 +292,6 @@ impl DeviceConfig {
         let audio_mode = AudioMode::try_from(cursor.read_u8())
             .ok()
             .unwrap_or(AudioMode::Disabled);
-        let audio_seed = cursor.read_u32();
         let latitude = cursor.read_f32();
         let longitude = cursor.read_f32();
         let has_location_timestamp = cursor.read_bool();
@@ -318,6 +317,7 @@ impl DeviceConfig {
                 .unwrap();
             device_name
         };
+        let audio_seed = cursor.read_u32();
 
         Some((
             DeviceConfigInner {

--- a/src/event_logger.rs
+++ b/src/event_logger.rs
@@ -238,7 +238,7 @@ impl EventLogger {
     }
 
     pub fn clear(&mut self, flash_storage: &mut OnboardFlash) {
-        if true || self.has_events_to_offload() {
+        if self.has_events_to_offload() {
             let start_block_index = FLASH_STORAGE_EVENT_LOG_START_BLOCK_INDEX;
             let end_block_index = FLASH_STORAGE_EVENT_LOG_END_BLOCK_INDEX;
             for block_index in start_block_index..end_block_index {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ use rp2040_hal::I2C;
 // NOTE: The version number here isn't important.  What's important is that we increment it
 //  when we do a release, so the tc2-agent can match against it and see if the version is correct
 //  for the agent software.
-pub const FIRMWARE_VERSION: u32 = 15;
+pub const FIRMWARE_VERSION: u32 = 16;
 pub const EXPECTED_ATTINY_FIRMWARE_VERSION: u8 = 1; // Checking against the attiny Major version. // TODO Check against minor version also.
                                                     // const ROSC_TARGET_CLOCK_FREQ_HZ: u32 = 150_000_000;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ use rp2040_hal::I2C;
 // NOTE: The version number here isn't important.  What's important is that we increment it
 //  when we do a release, so the tc2-agent can match against it and see if the version is correct
 //  for the agent software.
-pub const FIRMWARE_VERSION: u32 = 17;
+pub const FIRMWARE_VERSION: u32 = 18;
 pub const EXPECTED_ATTINY_FIRMWARE_VERSION: u8 = 1; // Checking against the attiny Major version. // TODO Check against minor version also.
                                                     // const ROSC_TARGET_CLOCK_FREQ_HZ: u32 = 150_000_000;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ use rp2040_hal::I2C;
 // NOTE: The version number here isn't important.  What's important is that we increment it
 //  when we do a release, so the tc2-agent can match against it and see if the version is correct
 //  for the agent software.
-pub const FIRMWARE_VERSION: u32 = 16;
+pub const FIRMWARE_VERSION: u32 = 17;
 pub const EXPECTED_ATTINY_FIRMWARE_VERSION: u8 = 1; // Checking against the attiny Major version. // TODO Check against minor version also.
                                                     // const ROSC_TARGET_CLOCK_FREQ_HZ: u32 = 150_000_000;
 

--- a/src/onboard_flash.rs
+++ b/src/onboard_flash.rs
@@ -50,7 +50,9 @@ const FEATURE_BLOCK_LOCK: u8 = 0xa0;
 const FEATURE_DIE_SELECT: u8 = 0xd0;
 
 const NUM_RECORDING_BLOCKS: isize = 2048 - 5; // Leave 1 block between recordings and event logs
-
+// event logger starts at 2044
+//last recording block should be 2042 
+2043
 struct FileAllocation {
     offset: u32,
     length: u32,
@@ -413,6 +415,7 @@ impl OnboardFlash {
         self.last_used_block_index = None;
         self.current_page_index = 0;
         self.current_block_index = 0;
+        let mut last_good_block = None;
         // Find first good free block:
         {
             self.read_page(0, 1).unwrap();
@@ -442,6 +445,7 @@ impl OnboardFlash {
                 }
             } else if block_index < NUM_RECORDING_BLOCKS {
                 good_block = true;
+                last_good_block = Some(block_index);
                 if !self.current_page.page_is_used() {
                     // This will be the starting block of the next file to be written.
                     if self.last_used_block_index.is_none() && self.first_used_block_index.is_some()
@@ -454,7 +458,6 @@ impl OnboardFlash {
                         println!("Setting next starting block index {}", block_index);
                     }
                 } else {
-                    let address = OnboardFlash::get_address(block_index, 0);
                     if self.first_used_block_index.is_none() {
                         // This is the starting block of the first file stored.
                         println!("Storing first used block {}", block_index);
@@ -466,6 +469,21 @@ impl OnboardFlash {
                     // need to transfer them one by one.  We won't remove any files until all
                     // the files have been transferred.
                 }
+            }
+        }
+
+        // if we have written write to the end of the flash need to handle this
+        if self.last_used_block_index.is_none() && self.first_used_block_index.is_some() {
+            if let Some(last_good_block) = last_good_block {
+                self.last_used_block_index = Some(last_good_block);
+                self.file_start_block_index = self.prev_page.file_start_block_index();
+
+                self.current_block_index = last_good_block + 1;
+                self.current_page_index = 0;
+                println!(
+                    "Setting next starting block index {}",
+                    self.current_block_index
+                );
             }
         }
         self.bad_blocks = bad_blocks;
@@ -523,7 +541,10 @@ impl OnboardFlash {
         // Need about 43 blocks for a 60 seconds recording at 48khz
         self.current_block_index > (NUM_RECORDING_BLOCKS - 44)
     }
-
+    pub fn is_full(&self) -> bool {
+        // check for page 62 incase it has to write one more page worth of data
+        self.current_block_index >= NUM_RECORDING_BLOCKS || (self.current_block_index == (NUM_RECORDING_BLOCKS-1) && self.current_page_index >= 62)
+    }
     pub fn is_nearly_full(&self) -> bool {
         // Lets us know when we should end the current recording.
         // We only need to allow a single frames worth – 2–3 blocks should be more than enough!

--- a/src/onboard_flash.rs
+++ b/src/onboard_flash.rs
@@ -50,9 +50,7 @@ const FEATURE_BLOCK_LOCK: u8 = 0xa0;
 const FEATURE_DIE_SELECT: u8 = 0xd0;
 
 const NUM_RECORDING_BLOCKS: isize = 2048 - 5; // Leave 1 block between recordings and event logs
-// event logger starts at 2044
-//last recording block should be 2042 
-2043
+
 struct FileAllocation {
     offset: u32,
     length: u32,
@@ -481,7 +479,7 @@ impl OnboardFlash {
                 self.current_block_index = last_good_block + 1;
                 self.current_page_index = 0;
                 println!(
-                    "Setting next starting block index {}",
+                    "Setting next starting block as last good block index {}",
                     self.current_block_index
                 );
             }
@@ -542,8 +540,10 @@ impl OnboardFlash {
         self.current_block_index > (NUM_RECORDING_BLOCKS - 44)
     }
     pub fn is_full(&self) -> bool {
-        // check for page 62 incase it has to write one more page worth of data
-        self.current_block_index >= NUM_RECORDING_BLOCKS || (self.current_block_index == (NUM_RECORDING_BLOCKS-1) && self.current_page_index >= 62)
+        // check for page 62 incase it has to write one more page worth of data when finalising
+        self.current_block_index >= NUM_RECORDING_BLOCKS
+            || (self.current_block_index == (NUM_RECORDING_BLOCKS - 1)
+                && self.current_page_index >= 62)
     }
     pub fn is_nearly_full(&self) -> bool {
         // Lets us know when we should end the current recording.


### PR DESCRIPTION
Always get last used block
Allow status recording if only a block exists
Always check for reset message in core0
Don't take audio recording if thermal window has less than 2 minutes to enforce a status recording