### PR TITLE
r31

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ use rp2040_hal::pio::PIOExt;
 // NOTE: The version number here isn't important.  What's important is that we increment it
 //  when we do a release, so the tc2-agent can match against it and see if the version is correct
 //  for the agent software.
-pub const FIRMWARE_VERSION: u32 = 30;
+pub const FIRMWARE_VERSION: u32 = 31;
 pub const EXPECTED_ATTINY_FIRMWARE_VERSION: u8 = 1; // Checking against the attiny Major version.
 // TODO Check against minor version also.
 const ROSC_TARGET_CLOCK_FREQ_HZ: u32 = 125_000_000;


### PR DESCRIPTION
- When waking the pi from low power mode to offload, we lose the alarm reason we woke, so make a new near future alarm right before we start the rPi, so that this doesn't happen.